### PR TITLE
Install singularity from OSG release repo and clean all yum cache data

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -10,8 +10,6 @@ RUN yum -y install https://repo.grid.iu.edu/osg/3.4/osg-3.4-el6-release-latest.r
     yum -y install  \
                    osg-wn-client \
                    osg-wn-client-glexec \
-                   redhat-lsb-core
-
-# Install Singularity
-RUN yum -y install --enablerepo=osg-upcoming-development singularity && \
-    yum clean all
+                   redhat-lsb-core \
+                   singularity && \
+    rm -rf /var/cache/yum/*


### PR DESCRIPTION
- When the Dockerfile was first made, singularity was only in osg-upcoming-development. Switch back to osg repo now that it has been released.
- Clear all the yum cache data

I'd suggest the same pattern of changes for all the Docker branches.